### PR TITLE
base.install: Fix debootstrap scripts

### DIFF
--- a/build/base.install
+++ b/build/base.install
@@ -122,6 +122,19 @@ bootstrap() {
     # Use debootstrap for debian based distribution
     if [ "$(package_type)" = "deb" ]; then
         check_binary debootstrap
+        case "$dist" in
+            $supported_debian_dists)
+                scripts="sid"
+                ;;
+            $supported_ubuntu_dists)
+                scripts="gutsy"
+                ;;
+        esac
+        if [ ! -e  /usr/share/debootstrap/scripts/${dist} ]; then
+            cd /usr/share/debootstrap/scripts
+            ln -s $scripts $dist
+            cd -
+        fi
         debootstrap --arch ${ARCH:=amd64} --variant=minbase $dist "$target" $repository
         # workaround no signature downloaded
         rm -f "$target"/var/lib/apt/lists/*[es]


### PR DESCRIPTION
debootstrap package could not support latest debian/ubuntu distribution.
The solution is just to add symlink in /usr/share/debootstrap/scripts/
to the correct release.
  - Debian : xxx -> sid
  - Ubuntu : xxx -> gutsy

Signed-off-by: Dimitri Savineau <dimitri.savineau@enovance.com>