### PR TITLE
mngids: raise an error if UID/GID is not in ids.tables

### DIFF
--- a/build/mngids.py
+++ b/build/mngids.py
@@ -64,28 +64,8 @@ def parse_cmdline(args, uids, gids, first=100, last=999, last_user=29999):
         index = get_index(args, opt) or get_index(args, '-' + opt[2])
 
         if not key in ids:
-            debug('mngids.py: %s not found (%s) in %s' % (key, opt, str(ids)))
-            if index:
-                try:
-                    ival = int(args[index + 1])
-                except:
-                    ival = None
-            else:
-                ival = None
-            if '-s' in args or '--system' in args or ival and ival < last:
-                f = first
-                l = last
-            else:
-                f = last + 1
-                l = last_user
-            vals = [ids[k][idx] for k in ids]
-            for loop in range(f, l):
-                if not str(loop) in vals:
-                    val = str(loop)
-                    break
-            else:
-                debug('no more id for %s in %s' % (key, ids))
-                return args
+            raise KeyError('mngids.py: %s not found (%s) in %s' %
+                           (key, opt, str(ids)))
         else:
             val = ids[key][idx]
 

--- a/build/test_mngids.py
+++ b/build/test_mngids.py
@@ -131,11 +131,10 @@ class TestMngids(unittest.TestCase):
         cmd = 'addgroup root'.split(' ')
         content = 'user:x:1000:'
         gids = {}
-        mngids.parse(content, gids)
-        mngids.parse_cmdline(cmd, {}, gids)
-        self.assertEquals(cmd[1], '--gid')
-        self.assertEquals(cmd[2], '1001')
- 
+        with self.assertRaises(KeyError):
+            mngids.parse(content, gids)
+            mngids.parse_cmdline(cmd, {}, gids)
+
     def test_parsecmdline_wrong_order(self):
         cmd = ['useradd', 'jenkins', '--shell', '/bin/bash',
                '--gid', 'cloud-users',


### PR DESCRIPTION
Instead of showing a simple debug message, fail the build if the UID/GID
is not mentionned in the ids.table file.

Close #173