### PR TITLE
build/mngids.py: Allow useradd without -g or --gid option

### DIFF
--- a/build/mngids.py
+++ b/build/mngids.py
@@ -118,7 +118,19 @@ def parse_cmdline(args, uids, gids, first=100, last=999, last_user=29999):
         if idx:
             insert(gids, args[idx + 1], 0, '--gid')
         else:
-            insert(uids, arg1, 1, '--gid')
+            # useradd can be called without a -g or --gid argument
+            # and in that case the useradd will create a group with
+            # the same id as the user id. So we only force --gid argument
+            # for groupadd.
+            idx2 = get_index(args, '-u') or get_index(args, '--uid')
+            if idx2:
+                uid = args[idx2 + 1]
+            else:
+                uid = uids[arg1][0]
+            if uids[arg1][1] != uid:
+                raise KeyError("adduser has been called without the argument -g or --gid in order to create (%s) " \
+                               "so adduser.real will create a group with the same gid as the user id (uid: %s). " \
+                               "BUT a different gid is provided in ids.tables (%s). Please fix ids.tables." % (arg1, uid, uids[arg1][1]))
         insert(uids, arg1, 0, '--uid')
     elif args0 == 'addgroup' or args0 == 'groupadd':
         insert(gids, arg1, 0, '--gid')


### PR DESCRIPTION
adduser/useradd can be called without a -g or --gid option,
and this results in an automatically created group (done by
useradd.real) with the same groupname as username and as well
the same gid as user id.

This patch also add a check to verified that if such a call happens
then the provided ids.tables must have gid == uid for that user. If
not the useradd fails with a KeyError and with an explanation message.