### PR TITLE
build: move ids.tables to /etc

### DIFF
--- a/build/base.install
+++ b/build/base.install
@@ -187,7 +187,7 @@ bootstrap() {
     # the commands with mngids.py
     cp -p ${ORIG}/mngids.py ${target}/usr/sbin/
     fake_shadow_utils
-    cp ${dir}/../ids.tables ${dir}/root/
+    cp ${dir}/../ids.tables ${dir}/etc/
 
     clean_mount_points
 }

--- a/build/check-ug.py
+++ b/build/check-ug.py
@@ -55,7 +55,7 @@ ARGS_OPTS = ['-g', '--gid',
              '-u', '--uid',
              '-Z', '--selinux-user']
 
-IDS = '/root/ids.tables'
+IDS = '/etc/ids.tables'
 try:
     exec(open(IDS).read())
 except IOError:

--- a/build/common
+++ b/build/common
@@ -276,8 +276,8 @@ cleanup() {
     fi
 
     # copy the ids file for later use
-    if [ -f ${dir}/root/ids.tables ]; then
-        cp ${dir}/root/ids.tables ${dir}/../ids.tables
+    if [ -f ${dir}/etc/ids.tables ]; then
+        cp ${dir}/etc/ids.tables ${dir}/../ids.tables
     fi
 
     # Verify the IDS are correct

--- a/build/mngids.py
+++ b/build/mngids.py
@@ -143,7 +143,7 @@ def main():
 
     debug('ORIG %s' % str(sys.argv))
 
-    IDS = '/root/ids.tables'
+    IDS = '/etc/ids.tables'
 
     try:
         exec(open(IDS).read())


### PR DESCRIPTION
Before, ids.tables was located in /root, but eDeploy use to upgrade by
excluding /root to avoid accidents.

We want to continue to exclude /root so we have to move ids.tables file
to /etc so we can ensure this file will be upgraded after each release.