### PR TITLE
build/edeploy: verify return code in pre/post scripts

### DIFF
--- a/build/edeploy
+++ b/build/edeploy
@@ -80,6 +80,12 @@ function upgrade() {
 
     if [ -x pre ]; then
         ./pre
+        RET=$?
+    fi
+
+    if [ "$RET" != "0" ]; then
+        echo "Upgrade process failed in pre script."
+        exit 1
     fi
 
     rsync -av --numeric-ids --delete-after --exclude-from=exclude rsync://${RSERV}:${RSERV_PORT}/${RPATH}/${TARGET}/${ROLE}/ / > ${EDEPLOY_DIR}/rsync_${VERS}_${TARGET}.out
@@ -102,6 +108,11 @@ function upgrade() {
         sync
         sleep 2
         reboot
+    fi
+
+    if [ "$RET" != "0" ]; then
+        echo "Upgrade process failed in post script."
+        exit 1
     fi
 }
 


### PR DESCRIPTION
Verify return codes from pre and post scripts, run during the upgrade.

Note for post: we run the test *after* the 100 value, because we
consider the script is successful only if it requires a reboot (code 100) or if it returns 0.

Otherwise, we fail the upgrade to avoid some actions in the scripts that
won't be executed.

This patchs requires 2 things:
* start a pre/post script by "set -e" so we stop at first failure.
* if an upgrade requires an upgrade, either don't finish by "exit 0" and
  let dpkg (or whatever tool return 100 code) doing it, or manually set
"exit 100".
* Otherwise, terminate a pre/post script by exit 0 to be sure we return 0.

With this new feature, we ensure upgrade will run pre/post actions and
fail if one of them is not working as expected (ie. directory creation).