### PR TITLE
build/edeploy: don't rsync with attributes for metadatas

### DIFF
--- a/build/edeploy
+++ b/build/edeploy
@@ -40,7 +40,7 @@ function update_metadata() {
     if [ ! -d ${EDEPLOY_DIR} ]; then
         mkdir -p ${EDEPLOY_DIR}
     fi
-    rsync -aX rsync://${RSERV}:${RSERV_PORT}/metadata/${VERS}/${ROLE}/${TARGET}/ ${EDEPLOY_DIR}/${ROLE_TO_UPDATE}/
+    rsync -a rsync://${RSERV}:${RSERV_PORT}/metadata/${VERS}/${ROLE}/${TARGET}/ ${EDEPLOY_DIR}/${ROLE_TO_UPDATE}/
 }
 
 function upgrade() {


### PR DESCRIPTION
During the upgrade, don't use -X rsync option, since we don't need files
attributes for metadata files (pre/post, ...).

Partial-bug #211