### PR TITLE
build/edeploy: set file security contexts after upgrade

### DIFF
--- a/build/edeploy
+++ b/build/edeploy
@@ -40,8 +40,8 @@ function update_metadata() {
     if [ ! -d ${EDEPLOY_DIR} ]; then
         mkdir -p ${EDEPLOY_DIR}
     fi
-    rsync -aX rsync://${RSERV}:${RSERV_PORT}/${RPATH}/${TARGET}/${ROLE}${EDEPLOY_DIR}/${ROLE_TO_UPDATE}/{pre,post} ${EDEPLOY_DIR}/${ROLE_TO_UPDATE}/ || :
-    rsync -aX rsync://${RSERV}:${RSERV_PORT}/metadata/${VERS}/${ROLE}/${TARGET}/ ${EDEPLOY_DIR}/${ROLE_TO_UPDATE}/
+    rsync -a rsync://${RSERV}:${RSERV_PORT}/${RPATH}/${TARGET}/${ROLE}${EDEPLOY_DIR}/${ROLE_TO_UPDATE}/{pre,post} ${EDEPLOY_DIR}/${ROLE_TO_UPDATE}/ || :
+    rsync -a rsync://${RSERV}:${RSERV_PORT}/metadata/${VERS}/${ROLE}/${TARGET}/ ${EDEPLOY_DIR}/${ROLE_TO_UPDATE}/
 }
 
 function upgrade() {
@@ -74,8 +74,8 @@ function upgrade() {
 
     # If we run a test upgrade, let's just show what the rsync would have change on the server
     if [ "$TEST_UPGRADE" = "1" ]; then
-        rsync --dry-run -aviX --numeric-ids --delete-after --exclude-from=exclude rsync://${RSERV}:${RSERV_PORT}/${RPATH}/${TARGET}/${ROLE}/ /
-        rsync --dry-run -aviX --numeric-ids --ignore-existing --include-from=add_only rsync://${RSERV}:${RSERV_PORT}/${RPATH}/${TARGET}/${ROLE}/ /
+        rsync --dry-run -avi --numeric-ids --delete-after --exclude-from=exclude rsync://${RSERV}:${RSERV_PORT}/${RPATH}/${TARGET}/${ROLE}/ /
+        rsync --dry-run -avi --numeric-ids --ignore-existing --include-from=add_only rsync://${RSERV}:${RSERV_PORT}/${RPATH}/${TARGET}/${ROLE}/ /
         return 0
     fi
 
@@ -83,8 +83,8 @@ function upgrade() {
         ./pre
     fi
 
-    rsync -avX --numeric-ids --delete-after --exclude-from=exclude rsync://${RSERV}:${RSERV_PORT}/${RPATH}/${TARGET}/${ROLE}/ / > ${EDEPLOY_DIR}/rsync_${VERS}_${TARGET}.out
-    rsync -avX --numeric-ids --ignore-existing --include-from=add_only rsync://${RSERV}:${RSERV_PORT}/${RPATH}/${TARGET}/${ROLE}/ / >> ${EDEPLOY_DIR}/rsync_${VERS}_${TARGET}.out
+    rsync -av --numeric-ids --delete-after --exclude-from=exclude rsync://${RSERV}:${RSERV_PORT}/${RPATH}/${TARGET}/${ROLE}/ / > ${EDEPLOY_DIR}/rsync_${VERS}_${TARGET}.out
+    rsync -av --numeric-ids --ignore-existing --include-from=add_only rsync://${RSERV}:${RSERV_PORT}/${RPATH}/${TARGET}/${ROLE}/ / >> ${EDEPLOY_DIR}/rsync_${VERS}_${TARGET}.out
 
     if [ -x post ]; then
         # suspend abort on error to get the exit code
@@ -94,7 +94,7 @@ function upgrade() {
         RET=$?
 
         set -e
-        
+
         # 0 or 100 are the only normal exit codes
         if [ $RET -ne 100 -a $RET -ne 0 ]; then
             exit $RET
@@ -103,6 +103,10 @@ function upgrade() {
         RET=0
     fi
 
+    # If SElinux is enabled, set file security contexts after the upgrade with the new file_contexts.
+    if [ -x /usr/sbin/selinuxenabled ] && /usr/sbin/selinuxenabled; then
+      setfiles -r / /etc/selinux/targeted/contexts/files/file_contexts /
+    fi
 
     echo -e "\nVersion ${TARGET}\n" > /etc/motd
     echo -e "VERS=${TARGET}\nROLE=${ROLE}\nRSERV=${RSERV}\nRSERV_PORT=${RSERV_PORT}\nRPATH=${RPATH}\n" > ${EDEPLOY_DIR}/conf

--- a/metadata/RH7.0-J.1.0.0/install-server/RH7.0-J.1.1.0/exclude
+++ b/metadata/RH7.0-J.1.0.0/install-server/RH7.0-J.1.1.0/exclude
@@ -56,6 +56,7 @@
 /run/
 /sys/
 /usr/bin/configure.sh
+/usr/bin/upgrade.sh
 /usr/bin/edeploy-nodes.sh
 /usr/bin/extract.py
 /usr/bin/generate.py


### PR DESCRIPTION
When you upgrade a system with SElinux enforced and there are some
contexts in the new role, the upgrade will fail like this:
rsync: rsync_xal_set:lsetxattr(""/usr/bin/cinder-volume"","security.selinux") failed: Invalid argument (22)

The idea here is to drop -X rsync option so we don't copy SElinux
attributes during the upgrade. Right after the rsync, if SElinux is
enforced we set the file security contexts by using the new file_contexts
so we ensure our system has the new and right contexts.